### PR TITLE
Enhancing API viewer to be less error prone

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,9 +39,18 @@ docs/
 
 The site is split into two pages:
 
-**[`index.html`](index.html)** is the API catalog. It displays a card for each available API with links to its documentation. When a user clicks "View Documentation," they are sent to `api-viewer.html` with query parameters identifying the API and version (e.g. `api-viewer.html?api=appstatus.yaml&version=v2`).
+**[`index.html`](index.html)** is the API catalog. It displays a card for each available API. Version links and the "View Documentation" button send users to `api-viewer.html` with query parameters identifying the API and version (e.g. `api-viewer.html?api=appstatus&version=v2`).
+
+Each catalog card must include one link with `class="active-version"` (under Active Version, or under In-Review when there is no active release). On page load, a small script copies that link's `href` onto the card's View Documentation button (`a.view-docs`).
 
 **[`api-viewer.html`](api-viewer.html)** is the Swagger UI viewer. It reads the `api` and `version` query parameters from the URL, looks up the corresponding spec file path in the `apiDefinitions` object, and renders it using Swagger UI. It also provides API and version selector dropdowns for switching between specs without returning to the catalog.
+
+Important details about `apiDefinitions`:
+
+- The **API key** (dropdown `value`, object key, and `?api=` query param) is an opaque catalog ID.
+- The actual OpenAPI file is only referenced under `versions.*.path` (e.g. `specs/appstatusv3.yaml`) in **[`api-viewer.html`](api-viewer.html)**.
+- List versions **oldest → newest**. When the API dropdown changes, the viewer rebuilds the version list and selects the **last** (newest) version by default.
+- Legacy bookmarks that still use `?api=foo.yaml` are accepted by stripping the `.yaml` suffix.
 
 ## Adding New API Documentation
 
@@ -49,12 +58,12 @@ To add a new API specification:
 
 1. Add your OpenAPI YAML file to the `docs/specs/` directory.
 
-2. Add an entry to the `apiDefinitions` object in [`api-viewer.html`](api-viewer.html):
+2. Add an entry to the `apiDefinitions` object in [`api-viewer.html`](api-viewer.html). Use a short ID without `.yaml` as the key; put the real filename only in `path`:
 
 ```javascript
 const apiDefinitions = {
   // ... existing entries ...
-  "your-api.yaml": {
+  "your-api": {
     name: "Your API Name",
     versions: {
       "v1": { path: "specs/your-api.yaml", displayName: "v1.0.0" }
@@ -63,16 +72,16 @@ const apiDefinitions = {
 };
 ```
 
-3. Add an `<option>` to the API selector dropdown in [`api-viewer.html`](api-viewer.html):
+3. Add an `<option>` to the API selector dropdown in [`api-viewer.html`](api-viewer.html). The `value` must match the `apiDefinitions` key exactly:
 
 ```html
-<select id="api-selector" onchange="loadSelectedAPI()">
+<select id="api-selector" onchange="onApiChange()">
   <!-- existing options -->
-  <option value="your-api.yaml">Your API Name</option>
+  <option value="your-api">Your API Name</option>
 </select>
 ```
 
-4. Add a card to the API grid in [`index.html`](index.html):
+4. Add a card to the API grid in [`index.html`](index.html). Mark the active version link with `class="active-version"` and leave the View Documentation button as `href="#"`:
 
 ```html
 <div class="api-card">
@@ -84,12 +93,13 @@ const apiDefinitions = {
         <div class="api-versions">
             <span>Active Version:</span>
             <ul>
-                <li><a href="api-viewer.html?api=your-api.yaml&version=v1">v1.0.0</a></li>
+                <li><a class="active-version" href="api-viewer.html?api=your-api&version=v1">v1.0.0</a></li>
             </ul>
             <span>Previous Versions:</span>
         </div>
     </div>
-    <a href="api-viewer.html?api=your-api.yaml&version=v1" class="btn btn-primary">View Documentation</a>
+    <!-- This href is replaced with the 'active-version' spec on page load -->
+    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
 </div>
 ```
 
@@ -101,10 +111,10 @@ To add a new version of an existing API:
 
 1. Add the new version's YAML file to `docs/specs/` (e.g. `your-api-v2.yaml`).
 
-2. Add the new version to the existing entry in the `apiDefinitions` object in [`api-viewer.html`](api-viewer.html):
+2. Add the new version to the existing entry in the `apiDefinitions` object in [`api-viewer.html`](api-viewer.html), **after** older versions so newest is last:
 
 ```javascript
-"your-api.yaml": {
+"your-api": {
   name: "Your API Name",
   versions: {
     "v1": { path: "specs/your-api.yaml", displayName: "v1.0.0" },
@@ -113,18 +123,18 @@ To add a new version of an existing API:
 }
 ```
 
-The version selector in `api-viewer.html` will automatically appear when multiple versions are available for an API.
+The version selector in `api-viewer.html` will automatically appear when multiple versions are available for an API. Switching APIs in the dropdown selects the newest version by default.
 
-3. Update the card in [`index.html`](index.html) to show the new active version and move the old version to "Previous Versions":
+3. Update the card in [`index.html`](index.html) to show the new active version (with `class="active-version"`) and move the old version to "Previous Versions". You do not need to change the View Documentation button — it still uses `href="#"` and picks up the new active link on page load:
 
 ```html
 <span>Active Version:</span>
 <ul>
-    <li><a href="api-viewer.html?api=your-api.yaml&version=v2">v2.0.0</a></li>
+    <li><a class="active-version" href="api-viewer.html?api=your-api&version=v2">v2.0.0</a></li>
 </ul>
 <span>Previous Versions:</span>
 <ul>
-    <li><a href="api-viewer.html?api=your-api.yaml&version=v1">v1.0.0</a></li>
+    <li><a href="api-viewer.html?api=your-api&version=v1">v1.0.0</a></li>
 </ul>
 ```
 

--- a/docs/api-viewer.html
+++ b/docs/api-viewer.html
@@ -17,21 +17,20 @@
             <nav class="api-selector-nav">
                 <div class="selector-group">
                     <label for="api-selector">API:</label>
-                    <select id="api-selector" onchange="loadSelectedAPI()">
-                        <option value="appstatus.yaml">Application Status API</option>
-                        <option value="appstatuspushNotifications1.yaml">Application Status Push Notifications API</option>
-                        <option value="producertraining.yaml">Producer Training Update</option>
-                        <option value="activatedannuityincome.yaml">Activated Annuity Income API</option>
-                        <option value="onetimewithdrawal1.yaml">One-Time Withdrawals API</option>
-                        <option value="onetimewithdrawalquote1.yaml">One-Time Withdrawal Quote API</option>
-                        <option value="systematicwithdrawalprogramsetup.yaml">Systematic Withdrawal Program Setup API</option>
-                        <option value="systematicwithdrawalprogramupdate.yaml">Systematic Withdrawal Program Update API</option>
-                        <option value="paperlessreplacements1.yaml">Paperless Replacements (RPL) API</option>
-                        <option value="fundtransfer.yaml">Fund Transfer API</option>
-                        <option value="policyinquiry.yaml">Policy Inquiry API</option>
-                        <option value="beneficiaryreplacementv1.yaml">Beneficiary Replacement API</option>
+                    <select id="api-selector" onchange="onApiChange()">
+                        <option value="appstatus">Application Status API</option>
+                        <option value="appstatuspushNotifications">Application Status Push Notifications API</option>
+                        <option value="producertraining">Producer Training Update</option>
+                        <option value="activatedannuityincome">Activated Annuity Income API</option>
+                        <option value="onetimewithdrawal">One-Time Withdrawals API</option>
+                        <option value="onetimewithdrawalquote">One-Time Withdrawal Quote API</option>
+                        <option value="systematicwithdrawalprogramsetup">Systematic Withdrawal Program Setup API</option>
+                        <option value="systematicwithdrawalprogramupdate">Systematic Withdrawal Program Update API</option>
+                        <option value="paperlessreplacements">Paperless Replacements (RPL) API</option>
+                        <option value="fundtransfer">Fund Transfer API</option>
+                        <option value="policyinquiry">Policy Inquiry API</option>
+                        <option value="beneficiaryreplacement">Beneficiary Replacement API</option>
                         <!-- Add more options as you add more APIs -->
-                        <!-- <option value="another-api/openapi.yaml">Another API</option> -->
                     </select>
                 </div>
                 <div class="selector-group">
@@ -52,9 +51,10 @@
     <script src="https://unpkg.com/swagger-ui-dist@5.18.2/swagger-ui-bundle.js" charset="UTF-8"></script>
     <script src="https://unpkg.com/swagger-ui-dist@5.18.2/swagger-ui-standalone-preset.js" charset="UTF-8"></script>
     <script>
-        // Define available APIs and their versions
+        // API keys are opaque catalog IDs (not filenames). Spec files are under versions.*.path.
+        // Order the specs from oldest to newest as the last version is the default in the dropdown.
         const apiDefinitions = {
-            "appstatus.yaml": {
+            "appstatus": {
                 name: "Application Status API",
                 versions: {
                     "v1": {
@@ -71,7 +71,7 @@
                     }
                 }
             },
-            "appstatuspushNotifications1.yaml": {
+            "appstatuspushNotifications": {
                 name: "Application Status Push Notifications API",
                 versions: {
                     "v1": {
@@ -80,8 +80,7 @@
                     }
                 }
             },
-
-            "producertraining.yaml": {
+            "producertraining": {
                 name: "Producer Training Update",
                 versions: {
                     "v1": {
@@ -90,7 +89,7 @@
                     }
                 }
             },
-            "activatedannuityincome.yaml": {
+            "activatedannuityincome": {
                 name: "Activated Annuity Income API",
                 versions: {
                     "v1": {
@@ -99,7 +98,7 @@
                     }
                 }
             },
-            "onetimewithdrawal1.yaml": {
+            "onetimewithdrawal": {
                 name: "One-Time Withdrawals API",
                 versions: {
                     "v1": {
@@ -108,7 +107,7 @@
                     }
                 }
             },
-            "onetimewithdrawalquote1.yaml": {
+            "onetimewithdrawalquote": {
                 name: "One-Time Withdrawal Quote API",
                 versions: {
                     "v1": {
@@ -117,7 +116,7 @@
                     }
                 }
             },
-            "systematicwithdrawalprogramsetup.yaml": {
+            "systematicwithdrawalprogramsetup": {
                 name: "Systematic Withdrawal Program Setup API",
                 versions: {
                     "v1": {
@@ -126,7 +125,7 @@
                     }
                 }
             },
-            "systematicwithdrawalprogramupdate.yaml": {
+            "systematicwithdrawalprogramupdate": {
                 name: "Systematic Withdrawal Program Update API",
                 versions: {
                     "v1": {
@@ -135,7 +134,7 @@
                     }
                 }
             },
-            "paperlessreplacements1.yaml": {
+            "paperlessreplacements": {
                 name: "Paperless Replacements (RPL) API",
                 versions: {
                     "v1": {
@@ -144,7 +143,7 @@
                     }
                 }
             },
-            "fundtransfer.yaml": {
+            "fundtransfer": {
                 name: "Fund Transfer API",
                 versions: {
                     "v1": {
@@ -153,7 +152,7 @@
                     }
                 }
             },
-            "policyinquiry.yaml": {
+            "policyinquiry": {
                 name: "Policy Inquiry API",
                 versions: {
                     "v1": {
@@ -166,7 +165,7 @@
                     }
                 }
             },
-            "beneficiaryreplacementv1.yaml": {
+            "beneficiaryreplacement": {
                 name: "Beneficiary Replacement API",
                 versions: {
                     "v1": {
@@ -178,6 +177,20 @@
         };
         // Add more APIs to the end of the object above as you add more APIs
 
+        // Accept legacy ?api=foo.yaml bookmarks by stripping the suffix.
+        function resolveApiKey(apiParam) {
+            if (!apiParam) return null;
+            if (apiDefinitions[apiParam]) return apiParam;
+            if (apiParam.endsWith('.yaml')) {
+                const withoutSuffix = apiParam.slice(0, -5);
+                if (apiDefinitions[withoutSuffix]) return withoutSuffix;
+            }
+            return null;
+        }
+
+        // Rebuild the Version dropdown for the given API key from apiDefinitions above.
+        // Options are inserted in object-key order (convention: oldest → newest).
+        // Hides the Version control entirely when the API has only one version.
         function populateVersionSelector(apiKey) {
             const versionSelector = document.getElementById('version-selector');
             versionSelector.innerHTML = '';
@@ -194,6 +207,23 @@
                 const versionSelectorGroup = versionSelector.closest('.selector-group');
                 versionSelectorGroup.style.display = Object.keys(versions).length > 1 ? 'flex' : 'none';
             }
+        }
+
+        // API selectordropdown onchange handler. Must rebuild versions before loading —
+        // otherwise the Version dropdown still holds the previous API's version key
+        // (e.g. "v3"), the lookup fails, and Swagger tries to fetch the raw API key.
+        // After rebuilding, select the last option (newest) then load that spec.
+        function onApiChange() {
+            const selectedAPI = document.getElementById('api-selector').value;
+            populateVersionSelector(selectedAPI);
+
+            // Prefer the newest version (last key; versions are listed oldest → newest).
+            const versionSelector = document.getElementById('version-selector');
+            if (versionSelector.options.length > 0) {
+                versionSelector.selectedIndex = versionSelector.options.length - 1;
+            }
+
+            loadSelectedAPI();
         }
 
         function loadSelectedAPI() {
@@ -237,10 +267,10 @@
             const versionParam = urlParams.get('version');
 
             const apiSelector = document.getElementById('api-selector');
+            const resolvedApi = resolveApiKey(apiParam);
 
-            // If API is specified in URL and exists in our definitions
-            if (apiParam && apiDefinitions[apiParam]) {
-                apiSelector.value = apiParam;
+            if (resolvedApi) {
+                apiSelector.value = resolvedApi;
             }
 
             const selectedAPI = apiSelector.value;
@@ -251,6 +281,9 @@
             // If version is specified in URL and exists for the selected API
             if (versionParam && apiDefinitions[selectedAPI]?.versions[versionParam]) {
                 versionSelector.value = versionParam;
+            } else if (versionSelector.options.length > 0) {
+                // Default to newest when URL has no usable version
+                versionSelector.selectedIndex = versionSelector.options.length - 1;
             }
 
             loadSelectedAPI();

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,12 @@
               <p>No available APIs at this time.</p>
             </div>
             -->
+            <!--
+              Each card must include one <a class="active-version" …> (usually under
+              Active Version, or In-Review when there is no active release). On page
+              load, script copies that href onto the card's 'View Documentation' button
+              (a.view-docs).
+            -->
             <div class="api-grid">
                 <!-- Application Status API Card -->
                 <div class="api-card">
@@ -59,16 +65,17 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=appstatus.yaml&version=v3">v3.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=appstatus&version=v3">v3.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=appstatus.yaml&version=v1">v1.0.0</a></li>
-                                <li><a href="api-viewer.html?api=appstatus.yaml&version=v2">v2.0.0</a></li>
+                                <li><a href="api-viewer.html?api=appstatus&version=v1">v1.0.0</a></li>
+                                <li><a href="api-viewer.html?api=appstatus&version=v2">v2.0.0</a></li>
                             </ul>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=appstatus.yaml&version=v3" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div>
                                 <!-- Application Status API Card -->
                 <div class="api-card">
@@ -80,14 +87,15 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?appstatuspushNotifications1.yaml&version=v3">v1.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=appstatuspushNotifications&version=v1">v1.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                             <ul>
                             </ul>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=appstatuspushNotifications1.yaml&version=v1" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div>
                 <!-- Producer Training Card -->
                 <div class="api-card">
@@ -99,12 +107,13 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=producertraining.yaml&version=v1">v1.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=producertraining&version=v1">v1.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=producertraining.yaml&version=v1" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div>
                 <!-- Activated Annuity Income API Card -->
                 <div class="api-card">
@@ -116,12 +125,13 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=activatedannuityincome.yaml&version=v1">v1.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=activatedannuityincome&version=v1">v1.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=activatedannuityincome.yaml&version=v1" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div>
                 <!-- One-Time Withdrawals API Card -->
                 <div class="api-card">
@@ -133,12 +143,13 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=onetimewithdrawal1.yaml&version=v1">v1.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=onetimewithdrawal&version=v1">v1.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=onetimewithdrawal1.yaml&version=v1" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div>
                 <!-- One-Time Withdrawal Quote API Card -->
                 <div class="api-card">
@@ -150,12 +161,13 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=onetimewithdrawalquote1.yaml&version=v1">v1.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=onetimewithdrawalquote&version=v1">v1.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=onetimewithdrawalquote1.yaml&version=v1" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div>
                 <!-- Systematic Withdrawal Program Setup Card -->
                 <div class="api-card">
@@ -167,12 +179,13 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=systematicwithdrawalprogramsetup.yaml&version=v1">v1.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=systematicwithdrawalprogramsetup&version=v1">v1.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=systematicwithdrawalprogramsetup.yaml&version=v1" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div>
                 <!-- Systematic Withdrawal Program Update Card -->
                 <div class="api-card">
@@ -184,12 +197,13 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=systematicwithdrawalprogramupdate.yaml&version=v1">v1.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=systematicwithdrawalprogramupdate&version=v1">v1.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=systematicwithdrawalprogramupdate.yaml&version=v1" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div>
                 <!-- Paperless Replacements API Card -->
                 <div class="api-card">
@@ -201,12 +215,13 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=paperlessreplacements1.yaml&version=v1">v1.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=paperlessreplacements&version=v1">v1.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=paperlessreplacements1.yaml&version=v1" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div>   
                 <!-- Fund Transfer API Card -->   
                 <div class="api-card">
@@ -218,12 +233,13 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=fundtransfer.yaml&version=v1">v1.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=fundtransfer&version=v1">v1.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=fundtransfer.yaml&version=v1" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div> 
                 <!-- Policy Inquiry API Card -->   
                 <div class="api-card">
@@ -235,15 +251,16 @@
                         <div class="api-versions">
                             <span>Active Version:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=policyinquiry.yaml&version=v2">v2.0.0</a></li>
+                                <li><a class="active-version" href="api-viewer.html?api=policyinquiry&version=v2">v2.0.0</a></li>
                             </ul>
                             <span>Previous Versions:</span>
                             <ul>
-                                <li><a href="api-viewer.html?api=policyinquiry.yaml&version=v1">v1.0.0</a></li>
+                                <li><a href="api-viewer.html?api=policyinquiry&version=v1">v1.0.0</a></li>
                             </ul>
                         </div>
                     </div>
-                    <a href="api-viewer.html?api=policyinquiry.yaml&version=v2" class="btn btn-primary">View Documentation</a>
+                    <!-- This href is replaced with the 'active-version' spec on page load -->
+                    <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div> 
                 <!-- Beneficiary Replacement Card -->
                 <div class="api-card">
@@ -258,11 +275,12 @@
                       </ul>
                       <span>In-Review Version:</span>
                       <ul>
-                        <li><a href="api-viewer.html?api=beneficiaryreplacementv1.yaml">v1.0.0</a></li>
+                        <li><a class="active-version" href="api-viewer.html?api=beneficiaryreplacement">v1.0.0</a></li>
                       </ul>
                     </div>
                   </div>
-                  <a href="api-viewer.html?api=beneficiaryreplacementv1.yaml" class="btn btn-primary">View Documentation</a>
+                  <!-- This href is replaced with the 'active-version' spec on page load -->
+                  <a href="#" class="btn btn-primary view-docs">View Documentation</a>
                 </div>
                 <!-- Add more divs here as you add more APIs -->
             </div>
@@ -337,6 +355,18 @@
         document.addEventListener('DOMContentLoaded', function () {
             const toggle = document.querySelector('.nav-dropdown-toggle');
             const menu = document.querySelector('.nav-dropdown-menu');
+
+            // Keep each card's 'View Documentation' button pointing at its Active (or In-Review) version link.
+            // If there are multiple 'active-version' links, the script will use the first one.
+            // If there are no 'active-version' links, the script will use the first '.api-versions a' link.
+            document.querySelectorAll('.api-card').forEach(card => {
+                const active = card.querySelector('a.active-version')
+                    || card.querySelector('.api-versions a');
+                const btn = card.querySelector('a.view-docs');
+                if (active && btn) {
+                    btn.href = active.getAttribute('href');
+                }
+            });
 
             toggle.addEventListener('click', function (e) {
                 e.preventDefault();


### PR DESCRIPTION
**Bug fixes:**
* Currently if you view a spec that has a V2 (like [Policy Inquiry](https://specs.dfa.irionline.org/api-viewer.html?api=policyinquiry.yaml&version=v2) ), then select a spec that doesn't have a V2 from the drop-down (like `Paperless Replacements`) you'll get an error as the drop-down looks for the same version as the last spec viewed:
<img width="870" height="452" alt="image" src="https://github.com/user-attachments/assets/9bf10121-946f-49e7-bd58-41a011e7a28e" />

Now the latest version is used when using the dropdown to switch between specs.  The 'latest' is the last one in the apiDefinitions array.


**Enhancements:**
* Automatically set the _View Documentation_ link in each card to be the `active-version` spec (so it doesn't accidentally get left pointing to an older version)
* Renamed the key for each spec to no longer have `.yaml` in the name as that implied that it should be updated when the actual yaml filename is changed or incremented...but it's actually just a key, not a filename.
